### PR TITLE
Multibox node representation

### DIFF
--- a/src/BoxNode.ts
+++ b/src/BoxNode.ts
@@ -1,0 +1,71 @@
+import { fabric } from "fabric";
+import { Node } from "./Node";
+import { Point } from "./Types";
+import Config = require("./Config");
+import { makeLine, calculateAngle, getBoxIntersection } from "./Utils";
+
+export class BoxNode extends Node {
+    constructor(data: number, canvas: fabric.Canvas) {
+        super(data, canvas);
+
+        const box = new fabric.Rect({
+            width: 2 * Config.NODE_SIZE,
+            height: Config.NODE_SIZE,
+            fill: '#00000000',
+            stroke: 'black',
+            strokeWidth: 2,
+        });
+
+        const divider = makeLine([0, -Config.NODE_SIZE / 2, 0, Config.NODE_SIZE / 2]);
+
+        const dot = new fabric.Circle({
+            radius: Config.NODE_SIZE / 8,
+            fill: 'black',
+            stroke: 'black',
+            strokeWidth: 2,
+            left: Config.NODE_SIZE / 2,
+        });
+
+        const text = new fabric.IText(this.data.toString(), {
+            fill: '#black',
+            left: -Config.NODE_SIZE / 2,
+        });
+
+        this.representation = new fabric.Group([box, divider, dot, text], {
+            hasControls: false,
+            hasBorders: false,
+            hoverCursor: "grab",
+            moveCursor: "grabbing",
+        });
+
+        canvas.add(this.representation);
+        this.representation.center();
+    }
+
+    public getHeadContactPoint(angle: number): Point {
+        return getBoxIntersection(this.getCenter(), angle + Math.PI,
+            this.representation.width, this.representation.height);
+    }
+
+    public getTailContactPoint(): Point {
+        return this.getDotLocation();
+    }
+
+    public getAngleTo(other: Node): number {
+        return calculateAngle(this.getDotLocation(), other.getCenter());
+    }
+
+    public getCenter(): Point {
+        return {
+            x: this.representation.left,
+            y: this.representation.top,
+        };
+    }
+
+    private getDotLocation(): Point {
+        return {
+            x: this.representation.left + Config.NODE_SIZE / 2,
+            y: this.representation.top,
+        };
+    }
+}

--- a/src/CircularNode.ts
+++ b/src/CircularNode.ts
@@ -2,6 +2,7 @@ import { fabric } from "fabric";
 import { Node } from "./Node";
 import { Point } from "./Types";
 import Config = require("./Config");
+import { calculateAngle } from "./Utils";
 
 export class CircularNode extends Node {
     constructor(data: number, canvas: fabric.Canvas) {
@@ -31,11 +32,19 @@ export class CircularNode extends Node {
         this.representation.center();
     }
 
-    public getContactPoint(angle: number): Point {
+    public getHeadContactPoint(angle: number): Point {
+        return this.getTailContactPoint(angle + Math.PI);
+    }
+
+    public getTailContactPoint(angle: number): Point {
         return {
             x: this.representation.left + Math.cos(angle) * Config.NODE_SIZE,
             y: this.representation.top + Math.sin(angle) * Config.NODE_SIZE,
         };
+    }
+
+    public getAngleTo(other: Node): number {
+        return calculateAngle(this.getCenter(), other.getCenter());
     }
 
     public getCenter(): Point {

--- a/src/CircularNode.ts
+++ b/src/CircularNode.ts
@@ -33,7 +33,10 @@ export class CircularNode extends Node {
     }
 
     public getHeadContactPoint(angle: number): Point {
-        return this.getTailContactPoint(angle + Math.PI);
+        return {
+            x: this.representation.left - Math.cos(angle) * Config.NODE_SIZE,
+            y: this.representation.top - Math.sin(angle) * Config.NODE_SIZE,
+        };
     }
 
     public getTailContactPoint(angle: number): Point {

--- a/src/CircularNode.ts
+++ b/src/CircularNode.ts
@@ -1,0 +1,47 @@
+import { fabric } from "fabric";
+import { Node } from "./Node";
+import { Point } from "./Types";
+import Config = require("./Config");
+
+export class CircularNode extends Node {
+    constructor(data: number, canvas: fabric.Canvas) {
+        super(data, canvas);
+
+        const circle = new fabric.Circle({
+            radius: Config.NODE_SIZE,
+            fill: '#00000000',
+            stroke: 'black',
+            strokeWidth: 2,
+        });
+
+        const text = new fabric.IText(this.data.toString(), {
+            fill: '#black',
+            evented: false,
+            selectable: false
+        });
+
+        this.representation = new fabric.Group([circle, text], {
+            hasControls: false,
+            hasBorders: false,
+            hoverCursor: "grab",
+            moveCursor: "grabbing",
+        });
+
+        canvas.add(this.representation);
+        this.representation.center();
+    }
+
+    public getContactPoint(angle: number): Point {
+        return {
+            x: this.representation.left + Math.cos(angle) * Config.NODE_SIZE,
+            y: this.representation.top + Math.sin(angle) * Config.NODE_SIZE,
+        };
+    }
+
+    public getCenter(): Point {
+        return {
+            x: this.representation.left,
+            y: this.representation.top,
+        };
+    }
+}

--- a/src/LinkedList.ts
+++ b/src/LinkedList.ts
@@ -2,7 +2,7 @@ import { fabric } from "fabric";
 import { Node } from "./Node";
 import { Variable } from "./Variable";
 import { Pointer } from "./Pointer";
-import { CircularNode } from "./CircularNode";
+import { BoxNode } from "./BoxNode";
 
 export class LinkedList {
 
@@ -52,7 +52,7 @@ export class LinkedList {
     }
 
     public createNode(value: number, pointerToNode: string): void {
-        const node = new CircularNode(value, this.canvas);
+        const node = new BoxNode(value, this.canvas);
         this.nodes.push(node);
         this.getPointerFromString(pointerToNode).set(node);
 

--- a/src/LinkedList.ts
+++ b/src/LinkedList.ts
@@ -2,6 +2,7 @@ import { fabric } from "fabric";
 import { Node } from "./Node";
 import { Variable } from "./Variable";
 import { Pointer } from "./Pointer";
+import { CircularNode } from "./CircularNode";
 
 export class LinkedList {
 
@@ -51,7 +52,7 @@ export class LinkedList {
     }
 
     public createNode(value: number, pointerToNode: string): void {
-        const node = new Node(value, this.canvas);
+        const node = new CircularNode(value, this.canvas);
         this.nodes.push(node);
         this.getPointerFromString(pointerToNode).set(node);
 

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -20,7 +20,11 @@ export abstract class Node {
      * Return the location where the pointer tail should touch this node.
      * @param angle the angle at which the pointer will be drawn, in radians.
      */
-    public abstract getContactPoint(angle: number): Point;
+    public abstract getTailContactPoint(angle: number): Point;
+
+    public abstract getHeadContactPoint(angle: number): Point;
 
     public abstract getCenter(): Point;
+
+    public abstract getAngleTo(other: Node): number;
 }

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1,39 +1,15 @@
 import { fabric } from "fabric";
 import { Pointer } from "./Pointer";
 import { Point } from "./Types";
-import Config = require("./Config");
 
-export class Node {
+export abstract class Node {
     public data: number;
     public next: Pointer
-    private representation: fabric.Group;
+    protected representation: fabric.Group;
 
     constructor(data: number, canvas: fabric.Canvas) {
         this.data = data;
         this.next = new Pointer(this, canvas);
-
-        const circle = new fabric.Circle({
-            radius: Config.NODE_SIZE,
-            fill: '#00000000',
-            stroke: 'black',
-            strokeWidth: 2,
-        });
-
-        const text = new fabric.IText(this.data.toString(), {
-            fill: '#black',
-            evented: false,
-            selectable: false
-        });
-
-        this.representation = new fabric.Group([circle, text], {
-            hasControls: false,
-            hasBorders: false,
-            hoverCursor: "grab",
-            moveCursor: "grabbing",
-        });
-
-        canvas.add(this.representation);
-        this.representation.center();
     }
 
     public draw(): void {
@@ -41,20 +17,10 @@ export class Node {
     }
 
     /**
-     * Return the location where the pointer touches this node.
+     * Return the location where the pointer tail should touch this node.
      * @param angle the angle at which the pointer will be drawn, in radians.
      */
-    public getContactPoint(angle: number): Point {
-        return {
-            x: this.representation.left + Math.cos(angle) * Config.NODE_SIZE,
-            y: this.representation.top + Math.sin(angle) * Config.NODE_SIZE,
-        };
-    }
+    public abstract getContactPoint(angle: number): Point;
 
-    public getCenter(): Point {
-        return {
-            x: this.representation.left,
-            y: this.representation.top,
-        };
-    }
+    public abstract getCenter(): Point;
 }

--- a/src/Pointer.ts
+++ b/src/Pointer.ts
@@ -30,13 +30,10 @@ export class Pointer {
     public draw(): void {
         if (this.destination === null) return;
 
-        const pointerAngle = Math.atan2(
-            this.destination.getCenter().y - this.origin.getCenter().y,
-            this.destination.getCenter().x - this.origin.getCenter().x,
-        );
+        const pointerAngle = this.origin.getAngleTo(this.destination);
 
-        const { x: x1, y: y1 } = this.origin.getContactPoint(pointerAngle);
-        const { x: x2, y: y2 } = this.destination.getContactPoint(pointerAngle + Math.PI);
+        const { x: x1, y: y1 } = this.origin.getTailContactPoint(pointerAngle);
+        const { x: x2, y: y2 } = this.destination.getHeadContactPoint(pointerAngle);
         const arrowAngles = [pointerAngle + 3 * Math.PI / 4, pointerAngle - 3 * Math.PI / 4];
 
         this.line.set({ x1, x2, y1, y2 });
@@ -52,5 +49,4 @@ export class Pointer {
             });
         }
     }
-
 }

--- a/src/Pointer.ts
+++ b/src/Pointer.ts
@@ -34,7 +34,7 @@ export class Pointer {
 
         const { x: x1, y: y1 } = this.origin.getTailContactPoint(pointerAngle);
         const { x: x2, y: y2 } = this.destination.getHeadContactPoint(pointerAngle);
-        const arrowAngles = [pointerAngle + 3 * Math.PI / 4, pointerAngle - 3 * Math.PI / 4];
+        const arrowAngles = [pointerAngle + 0.85 * Math.PI, pointerAngle - 0.85 * Math.PI];
 
         this.line.set({ x1, x2, y1, y2 });
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -15,3 +15,24 @@ export function makeLine(coords: number[] = [0, 0, 0, 0]): fabric.Line {
 export function calculateAngle(p1: Point, p2: Point): number {
     return Math.atan2(p2.y - p1.y, p2.x - p1.x);
 }
+
+/**
+ * Calculates the point at which a ray drawn from the center of a box intersects the box boundrary.
+ * @param center center of the box
+ * @param angle angle at which ray is drawn, with respect to the positive x-axis
+ * @param width width of the box
+ * @param height height of the box
+ */
+export function getBoxIntersection(center: Point, angle: number, width: number, height: number): Point {
+    // r is distance from center to contact point
+    // take minimum to determine if it intersects the vertical or horizontal boundary first
+    const r = Math.min(
+        Math.abs((width / 2) / Math.cos(angle)),
+        Math.abs((height / 2) / Math.sin(angle))
+    );
+
+    return {
+        x: center.x + Math.cos(angle) * r,
+        y: center.y + Math.sin(angle) * r
+    };
+}

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,12 +1,17 @@
 import { fabric } from "fabric";
+import { Point } from "./Types";
 
 
 export function makeLine(coords: number[] = [0, 0, 0, 0]): fabric.Line {
     return new fabric.Line(coords, {
-      fill: 'black',
-      stroke: 'black',
-      strokeWidth: 2,
-      selectable: false,
-      evented: false,
+        fill: 'black',
+        stroke: 'black',
+        strokeWidth: 2,
+        selectable: false,
+        evented: false,
     });
+}
+
+export function calculateAngle(p1: Point, p2: Point): number {
+    return Math.atan2(p2.y - p1.y, p2.x - p1.x);
 }

--- a/src/Variable.ts
+++ b/src/Variable.ts
@@ -1,6 +1,8 @@
 import { fabric } from "fabric";
 import { Pointer } from "./Pointer";
 import { Point } from "./Types";
+import { Node } from "./Node";
+import { calculateAngle } from "./Utils";
 
 export class Variable {
     private name: string;
@@ -44,7 +46,7 @@ export class Variable {
      * Return the location where the pointer touches this variable on the canvas.
      * @param angle the angle at which the pointer will be drawn, in radians.
      */
-    public getContactPoint(angle: number): Point {
+    public getTailContactPoint(angle: number): Point {
         // r is distance from center to contact point
         // take minimum to determine if it intersects the vertical or horizontal boundary first
         const r = Math.min(
@@ -56,6 +58,10 @@ export class Variable {
             x: this.representation.left + Math.cos(angle) * r,
             y: this.representation.top + Math.sin(angle) * r
         };
+    }
+
+    public getAngleTo(other: Node): number {
+        return calculateAngle(this.getCenter(), other.getCenter());
     }
 
     public getCenter(): Point {

--- a/src/Variable.ts
+++ b/src/Variable.ts
@@ -2,7 +2,7 @@ import { fabric } from "fabric";
 import { Pointer } from "./Pointer";
 import { Point } from "./Types";
 import { Node } from "./Node";
-import { calculateAngle } from "./Utils";
+import { calculateAngle, getBoxIntersection } from "./Utils";
 
 export class Variable {
     private name: string;
@@ -47,17 +47,8 @@ export class Variable {
      * @param angle the angle at which the pointer will be drawn, in radians.
      */
     public getTailContactPoint(angle: number): Point {
-        // r is distance from center to contact point
-        // take minimum to determine if it intersects the vertical or horizontal boundary first
-        const r = Math.min(
-            Math.abs((this.representation.width / 2) / Math.cos(angle)),
-            Math.abs((this.representation.height / 2) / Math.sin(angle))
-        );
-
-        return {
-            x: this.representation.left + Math.cos(angle) * r,
-            y: this.representation.top + Math.sin(angle) * r
-        };
+        return getBoxIntersection(this.getCenter(), angle,
+            this.representation.width, this.representation.height);
     }
 
     public getAngleTo(other: Node): number {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8812440/83076498-489d3b80-a03b-11ea-9ba6-15dcf871626d.png)

To switch back to the circular node representation, just change `BoxNode` to `CircularNode` in the `createNode` function:

https://github.com/SethPoulsen/data-structures-playground/blob/5d7611741468c57b1c32462df4455f972e568abc/src/LinkedList.ts#L54-L55