### PR TITLE
Adding undo/redo operations

### DIFF
--- a/src/DSPlayground.ts
+++ b/src/DSPlayground.ts
@@ -1,5 +1,6 @@
 import { LinkedList } from "./LinkedList";
 import { validateVariableName } from "./VariableValidation";
+import { DSOperation, CreateNode, CreatePointer, AssignPointer } from "./Operations";
 
 function setControlsBoxStyle(control: HTMLDivElement) {
     control.style.width = "33%";
@@ -12,6 +13,13 @@ function setControlsBoxStyle(control: HTMLDivElement) {
 export class DSPlayground {
 
     private controls: HTMLDivElement;
+
+    private undoButton: HTMLButtonElement;
+    private redoButton: HTMLButtonElement;
+    private undoStack: DSOperation[] = [];
+    private redoStack: DSOperation[] = [];
+
+    private linkedList: LinkedList;
 
     private createControlsDiv(html: string) {
         const div = document.createElement("div");
@@ -75,12 +83,12 @@ export class DSPlayground {
             </div
         `);
 
-        const reassignPointerDiv = this.createControlsDiv(`
+        const assignPointerDiv = this.createControlsDiv(`
             <div style="font-size: 1.2em; padding: 2px;" >
-                <u> Move/Reassign a pointer </u>
+                <u> Assign a pointer </u>
             </div> <div></div>
             <div style="padding: 2px;">
-                Reassign the pointer
+                Assign the pointer
                 <select> </select>
 
             </div>
@@ -89,47 +97,90 @@ export class DSPlayground {
                 <select> </select>
             </div>
             <div style="padding: 2px;">
-                <button id="reassignPointerButton"
+                <button id="assignPointerButton"
                     style="float:right; background-color: #87CEFA; height: 30px; width: 100px">
-                    Reassign!
+                    Assign!
                 </button>
             </div
         `);
 
         // TODO: create another controls box for the user to input a list of numbers
         // to initialize the list
-        const ll = new LinkedList(canvasEl);
+
+        this.createControlsDiv(`
+            <div style="padding: 2px;">
+                <button id="undoButton"
+                    style="background-color: #87CEFA; height: 30px; width: 100px">
+                    Undo
+                </button>
+                <button id="redoButton"
+                    style="background-color: #87CEFA; height: 30px; width: 100px">
+                    Redo
+            </button>
+            </div
+        `);
+
+        this.linkedList = new LinkedList(canvasEl);
 
         createPointerDiv.querySelector("button").addEventListener("click", () => {
             const inputEl = createPointerDiv.querySelector("input");
             const pointerName = inputEl.value.trim();
             inputEl.value = "";
 
-            if (!validateVariableName(pointerName, ll.getAccessibleNames())) {
+            if (!validateVariableName(pointerName, this.linkedList.getAccessibleNames())) {
                 return;
             }
 
-            ll.createPointer(pointerName);
-            this.updateDropdownOptions(ll);
+            this.performOperation(new CreatePointer(pointerName));
+
+            inputEl.value = "";
+            this.updateDropdownOptions(this.linkedList);
+
         });
 
         createNodeDiv.querySelector("button").addEventListener("click", () => {
             const inputEl = createNodeDiv.querySelector("input");
             const selectEl = createNodeDiv.querySelector("select");
             const pointerName = selectEl.selectedOptions[0].value;
-            ll.createNode(parseInt(inputEl.value), pointerName);
+
+            const operation = new CreateNode(parseInt(inputEl.value), pointerName);
+            this.performOperation(operation);
+
             inputEl.value = "";
-            this.updateDropdownOptions(ll);
+            this.updateDropdownOptions(this.linkedList);
         });
 
-        reassignPointerDiv.querySelector("button").addEventListener("click", () => {
-            const selectEls = reassignPointerDiv.querySelectorAll("select");
-
+        assignPointerDiv.querySelector("button").addEventListener("click", () => {
+            const selectEls = assignPointerDiv.querySelectorAll("select");
             const lhsPointer = selectEls[0].selectedOptions[0].value;
             const rhsPointer = selectEls[1].selectedOptions[0].value;
-            ll.reassignPointer(lhsPointer, rhsPointer);
-            this.updateDropdownOptions(ll);
+
+            const operation = new AssignPointer(lhsPointer, rhsPointer);
+            this.performOperation(operation);
+
+            this.updateDropdownOptions(this.linkedList);
         });
+
+        this.undoButton = <HTMLButtonElement> document.getElementById("undoButton");
+        this.undoButton.addEventListener("click", () => {
+            const lastOp = this.undoStack.pop();
+            if (!lastOp) {
+                return;
+            }
+            this.undoOperation(lastOp);
+            this.redoStack.push(lastOp);
+        });
+
+        this.redoButton = <HTMLButtonElement> document.getElementById("redoButton");
+        this.redoButton.addEventListener("click", () => {
+            const lastOp = this.redoStack.pop();
+            if (!lastOp) {
+                return;
+            }
+            this.performOperationInternal(lastOp);
+            this.undoStack.push(lastOp);
+        });
+
     }
 
     private updateDropdownOptions(ll: LinkedList): void {
@@ -139,4 +190,36 @@ export class DSPlayground {
         }
         this.controls.querySelectorAll("select").forEach(selectEl => selectEl.innerHTML = options);
     }
+
+    private performOperation(op: DSOperation): void {
+        this.performOperationInternal(op);
+        this.redoStack = []; // TODO also grey out UI to show its not usable
+        this.undoStack.push(op);
+    }
+
+    private undoOperation(op: DSOperation): void {
+        if (op.type === "CreateNode") {
+            this.linkedList.unCreateNode(op as CreateNode);
+        } else if (op.type === "CreatePointer") {
+            this.linkedList.unCreatePointer(op as CreatePointer);
+        } else if (op.type === "AssignPointer") {
+            this.linkedList.unAssignPointer(op as AssignPointer);
+        } else {
+            throw(new Error("Unsupported Operation"));
+        }
+    }
+
+    private performOperationInternal(op: DSOperation): void {
+        if (op.type === "CreateNode") {
+            (op as CreateNode).oldDestination = this.linkedList.createNode(op as CreateNode);
+        } else if (op.type === "CreatePointer") {
+            this.linkedList.createPointer(op as CreatePointer);
+        } else if (op.type === "AssignPointer") {
+            (op as AssignPointer).oldDestination = this.linkedList.assignPointer(op as AssignPointer);
+        } else {
+            throw(new Error("Unsupported Operation"));
+        }
+    }
+
+
 }

--- a/src/DSPlayground.ts
+++ b/src/DSPlayground.ts
@@ -1,6 +1,7 @@
 import { LinkedList } from "./LinkedList";
 import { validateVariableName } from "./VariableValidation";
 import { DSOperation, CreateNode, CreatePointer, AssignPointer } from "./Operations";
+import { generateFreshID } from "./IdGenerator";
 
 function setControlsBoxStyle(control: HTMLDivElement) {
     control.style.width = "33%";
@@ -143,7 +144,9 @@ export class DSPlayground {
             const selectEl = createNodeDiv.querySelector("select");
             const pointerName = selectEl.selectedOptions[0].value;
 
-            const operation = new CreateNode(parseInt(inputEl.value), pointerName);
+            const newNodeId = generateFreshID();
+            const assignPointer = new AssignPointer(pointerName, newNodeId, this.linkedList.getNodeIdAt(pointerName));
+            const operation = new CreateNode(parseInt(inputEl.value), newNodeId, assignPointer);
             this.performOperation(operation);
 
             inputEl.value = "";
@@ -155,7 +158,10 @@ export class DSPlayground {
             const lhsPointer = selectEls[0].selectedOptions[0].value;
             const rhsPointer = selectEls[1].selectedOptions[0].value;
 
-            const operation = new AssignPointer(lhsPointer, rhsPointer);
+            const operation = new AssignPointer(lhsPointer,
+                this.linkedList.getNodeIdAt(rhsPointer),
+                this.linkedList.getNodeIdAt(lhsPointer));
+
             this.performOperation(operation);
 
             this.updateDropdownOptions(this.linkedList);
@@ -211,11 +217,11 @@ export class DSPlayground {
 
     private performOperationInternal(op: DSOperation): void {
         if (op.type === "CreateNode") {
-            (op as CreateNode).oldDestination = this.linkedList.createNode(op as CreateNode);
+            this.linkedList.createNode(op as CreateNode);
         } else if (op.type === "CreatePointer") {
             this.linkedList.createPointer(op as CreatePointer);
         } else if (op.type === "AssignPointer") {
-            (op as AssignPointer).oldDestination = this.linkedList.assignPointer(op as AssignPointer);
+            this.linkedList.assignPointer(op as AssignPointer);
         } else {
             throw(new Error("Unsupported Operation"));
         }

--- a/src/IdGenerator.ts
+++ b/src/IdGenerator.ts
@@ -1,0 +1,5 @@
+
+let idCounter = 1;
+export function generateFreshID(): number {
+    return idCounter++;
+}

--- a/src/LinkedList.ts
+++ b/src/LinkedList.ts
@@ -54,15 +54,15 @@ export class LinkedList {
 
     public createNode(op: CreateNode): void {
         const node = new BoxNode(op.value, op.id, this.canvas,
-            this.getPointerFromString(op.pointer.lhs).getOriginLocation());
+            this.getPointerFromString(op.assignSuboperation.pointer).getOriginLocation());
         this.nodes[op.id] = node;
-        this.assignPointer(op.pointer);
+        this.assignPointer(op.assignSuboperation);
         this.draw();
     }
 
     public assignPointer(op: AssignPointer): void {
-        const lhsPointer = this.getPointerFromString(op.lhs);
-        lhsPointer.set(this.nodes[op.nodeId]);
+        const lhsPointer = this.getPointerFromString(op.pointer);
+        lhsPointer.set(this.nodes[op.newNodeId]);
         this.draw();
     }
 
@@ -73,7 +73,7 @@ export class LinkedList {
 
     public unCreateNode(op: CreateNode): void {
         // put the pointer back where it was
-        this.unAssignPointer(op.pointer);
+        this.unAssignPointer(op.assignSuboperation);
 
         // get rid of the node
         this.nodes[op.id].erase();
@@ -82,7 +82,7 @@ export class LinkedList {
     }
 
     public unAssignPointer(op: AssignPointer): void {
-        this.getPointerFromString(op.lhs).set(this.nodes[op.oldNodeId]);
+        this.getPointerFromString(op.pointer).set(this.nodes[op.oldNodeId]);
         this.draw();
     }
 

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -7,9 +7,11 @@ export abstract class Node {
     public data: number;
     public next: Pointer
     protected representation: fabric.Group;
+    private canvas: fabric.Canvas;
 
     constructor(data: number, canvas: fabric.Canvas, pointerOrigin: Point) {
         this.data = data;
+        this.canvas = canvas;
         this.next = new Pointer(this, canvas);
 
         this.representation = new fabric.Group(this.createFabricObjects(), {
@@ -41,4 +43,9 @@ export abstract class Node {
     public abstract getCenter(): Point;
 
     public abstract getAngleTo(other: Node): number;
+
+    public erase(): void {
+        this.canvas.remove(this.representation);
+        this.next.erase();
+    }
 }

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -3,16 +3,19 @@ import { Pointer } from "./Pointer";
 import { Point } from "./Types";
 import Config = require("./Config");
 
+
 export abstract class Node {
     public data: number;
     public next: Pointer
     protected representation: fabric.Group;
     private canvas: fabric.Canvas;
+    private id: number;
 
-    constructor(data: number, canvas: fabric.Canvas, pointerOrigin: Point) {
+    constructor(data: number, id: number, canvas: fabric.Canvas, pointerOrigin: Point) {
         this.data = data;
         this.canvas = canvas;
         this.next = new Pointer(this, canvas);
+        this.id = id;
 
         this.representation = new fabric.Group(this.createFabricObjects(), {
             hasControls: false,
@@ -48,4 +51,9 @@ export abstract class Node {
         this.canvas.remove(this.representation);
         this.next.erase();
     }
+
+    public getId(): number {
+        return this.id;
+    }
+
 }

--- a/src/Operations.ts
+++ b/src/Operations.ts
@@ -1,0 +1,38 @@
+import { Node } from "./Node";
+
+export interface DSOperation {
+    type: string;
+}
+
+export class CreateNode implements DSOperation {
+    public type = "CreateNode";
+    public value: number;
+    public pointer: string;
+    public oldDestination: Node;
+
+    constructor(value: number, pointer: string) {
+        this.value = value;
+        this.pointer = pointer;
+    }
+}
+
+export class CreatePointer implements DSOperation {
+    type = "CreatePointer";
+    name: string;
+
+    constructor(name: string) {
+        this.name = name;
+    }
+}
+
+export class AssignPointer implements DSOperation {
+    public type = "AssignPointer";
+    public lhs: string;
+    public rhs: string;
+    public oldDestination: Node;
+
+    constructor(lhs: string, rhs: string) {
+        this.lhs = lhs;
+        this.rhs = rhs;
+    }
+}

--- a/src/Operations.ts
+++ b/src/Operations.ts
@@ -7,12 +7,12 @@ export class CreateNode implements DSOperation {
     public type = "CreateNode";
     public value: number;
     public id: number;
-    public pointer: AssignPointer;
+    public assignSuboperation: AssignPointer;
 
-    constructor(value: number, id: number, pointer: AssignPointer) {
+    constructor(value: number, id: number, assignSuboperation: AssignPointer) {
         this.value = value;
         this.id = id;
-        this.pointer = pointer;
+        this.assignSuboperation = assignSuboperation;
     }
 }
 
@@ -27,13 +27,13 @@ export class CreatePointer implements DSOperation {
 
 export class AssignPointer implements DSOperation {
     public type = "AssignPointer";
-    public lhs: string;
-    public nodeId: number;
+    public pointer: string;
+    public newNodeId: number;
     public oldNodeId: number;
 
-    constructor(lhs: string, nodeId: number, oldNodeId: number) {
-        this.lhs = lhs;
-        this.nodeId = nodeId;
+    constructor(pointer: string, newNodeId: number, oldNodeId: number) {
+        this.pointer = pointer;
+        this.newNodeId = newNodeId;
         this.oldNodeId = oldNodeId;
     }
 }

--- a/src/Operations.ts
+++ b/src/Operations.ts
@@ -1,4 +1,3 @@
-import { Node } from "./Node";
 
 export interface DSOperation {
     type: string;
@@ -7,11 +6,12 @@ export interface DSOperation {
 export class CreateNode implements DSOperation {
     public type = "CreateNode";
     public value: number;
-    public pointer: string;
-    public oldDestination: Node;
+    public id: number;
+    public pointer: AssignPointer;
 
-    constructor(value: number, pointer: string) {
+    constructor(value: number, id: number, pointer: AssignPointer) {
         this.value = value;
+        this.id = id;
         this.pointer = pointer;
     }
 }
@@ -28,11 +28,12 @@ export class CreatePointer implements DSOperation {
 export class AssignPointer implements DSOperation {
     public type = "AssignPointer";
     public lhs: string;
-    public rhs: string;
-    public oldDestination: Node;
+    public nodeId: number;
+    public oldNodeId: number;
 
-    constructor(lhs: string, rhs: string) {
+    constructor(lhs: string, nodeId: number, oldNodeId: number) {
         this.lhs = lhs;
-        this.rhs = rhs;
+        this.nodeId = nodeId;
+        this.oldNodeId = oldNodeId;
     }
 }

--- a/src/Pointer.ts
+++ b/src/Pointer.ts
@@ -16,15 +16,17 @@ export class Pointer {
     constructor(origin: Node | Variable, canvas: fabric.Canvas) {
         this.origin = origin;
         this.canvas = canvas;
-        this.destination = null;
-        this.canvas = canvas;
         this.line = makeLine();
         this.selfLoop = new fabric.Path("",{ fill: '', stroke: 'black', objectCaching: false, strokeWidth: 2 });
         this.arrowhead = [makeLine(), makeLine()];
-        canvas.add(this.line, ...this.arrowhead);
     }
 
     public set(nodePointedTo: Node): void {
+        if (!this.destination && nodePointedTo) {
+            this.canvas.add(this.line, ...this.arrowhead);
+        } else if (this.destination && !nodePointedTo) {
+            this.erase();
+        }
         this.destination = nodePointedTo;
 
         this.erase();
@@ -41,7 +43,7 @@ export class Pointer {
     }
 
     public draw(): void {
-        if (this.destination === null) return;
+        if (!this.destination) return;
 
         let x1, y1, x2, y2, pointerAngle;
         if (this.destination == this.origin) {

--- a/src/Pointer.ts
+++ b/src/Pointer.ts
@@ -52,9 +52,13 @@ export class Pointer {
             ({ x: x2, y: y2 } = this.destination.getHeadContactPoint(0));
 
             const size = Config.NODE_SIZE * 3;
-            this.selfLoop.set("path", [
-                <any>["m", x1, y1],
-                <any>["c", size , -size , -size * 3/2, -size, x2 - x1, 0]
+
+            this.selfLoop.set("path", <fabric.Point[]><unknown>[
+                // the fabric.js type declaration is incorrect, stating that this
+                // method expects a fabric.Point[], but it actually expects a string[][]
+                // denoting an SVG path
+                ["m", x1, y1],
+                ["c", size , -size , -size * 3/2, -size, x2 - x1, 0]
             ]);
 
         } else {

--- a/src/Pointer.ts
+++ b/src/Pointer.ts
@@ -15,6 +15,7 @@ export class Pointer {
 
     constructor(origin: Node | Variable, canvas: fabric.Canvas) {
         this.origin = origin;
+        this.canvas = canvas;
         this.destination = null;
         this.canvas = canvas;
         this.line = makeLine();
@@ -81,4 +82,5 @@ export class Pointer {
     public erase(): void {
         this.canvas.remove(this.line, this.selfLoop, ...this.arrowhead);
     }
+
 }

--- a/src/Variable.ts
+++ b/src/Variable.ts
@@ -8,9 +8,11 @@ export class Variable {
     private name: string;
     public pointer: Pointer;
     private representation: fabric.Group;
+    private canvas: fabric.Canvas;
 
     constructor(name: string, canvas: fabric.Canvas) {
         this.name = name;
+        this.canvas = canvas;
         this.pointer = new Pointer(this, canvas);
 
         const text = new fabric.IText(this.name, {
@@ -62,4 +64,10 @@ export class Variable {
             y: this.representation.top,
         };
     }
+
+    public erase() : void {
+        this.canvas.remove(this.representation);
+        this.pointer.erase();
+    }
+
 }

--- a/src/Variable.ts
+++ b/src/Variable.ts
@@ -35,7 +35,7 @@ export class Variable {
 
     public getAccessibleNames(): string[] {
         const pointers = [this.name];
-        if (this.pointer.deref() !== null) {
+        if (this.pointer.deref()) {
             pointers.push(this.name + "->next");
         }
         return pointers;


### PR DESCRIPTION
@jasonxia17  Everything here is working, but there are a few things that I'm not totally happy about that I would love to have your input on: 

Minor: 
- I'm not thrilled about every object holds a reference to the canvas now, but its probably unavoidable if we want them to be able to erase themselves, so I guess its ok. The other option is to pass in the canvas to all the erase() methods, but I'm not sure that's much better. 
- The placement of the undo/redo buttons is honestly a bit ugly. I'm not a designer. I'm definitely open to suggestions here on where to put them.
- I dislike the code duplication between `CreateNode` and `AssignPointer`. It would be nice if the `CreateNode` action *only* created the node, and then an `AssignPointer` action could be done right afterward. May be we could do it by having invisible internal pointer that we can use, and can show up in serialized action objects, but the user can't see or use? 

Major:
My biggest issue is this: I hate that the `CreateNode` and `AssignPointer` have a reference to a Node object. The reason why, is because I want to be able to serialze lists of actions in order to save state (for grading students, for students being able to save their work and come back to it, etc.), and if you are serializing a list of actions, it should really just have pointer names and values in it, not actual `Node` objects. The `unAssignPointer` and `unCreateNode` methods only work because they get a reference to an actual node object, but this would break if the actions had been serialized and deserialized as JSON at some point. (So if a student saved their work and came back later, they would no longer be able to undo actions from before).

There are a couple of ways around this I can think of, but I'm not sure I like them either: 
1. each time an undo assignment is done, find out where the pointer was previously pointing by going back through all the actions from the beginning
2. instead of keeping track of actions, record the entire state of the diagram after each action.

The thing about (1) that is a bit attractive to me is that having a way of figuring out what list a set of actions creates would be useful for other purposes too, such as automated testing, and having a lightweight script on the backend to grade student homeworks (i.e. the student uses the UI to build a linked list, the PrairieLearn frontend sends the backend a list of actions, the backend "executes" the actions to make sure they construct the correct linked list) . One way to do this would be to abstract away `fabric.Canvas` with an interface. We could have a dummy canvas object that does absolutely nothing. If we want to find out what list is constructed by a given series of actions, we can just create a DSPlayground with a dummy canvas, have it execute the actions really quick, then ask it whatever we wanted to about its state. The downside is that this is computationally intensive, so it would be nice to have a way to undo that is more elegant that completely reconstructing the old state.